### PR TITLE
Improve readability of Italian landing page about section

### DIFF
--- a/css/pages/landingPage.css
+++ b/css/pages/landingPage.css
@@ -236,15 +236,21 @@
     2.5. MID SECTION ENHANCEMENTS
 ───────────────────────────────────────────────────────────────────────────────*/
 #about-section {
-  background: linear-gradient(145deg, 
-    #ffffff 0%, 
-    rgba(211, 232, 224, 0.1) 50%, 
+  background: linear-gradient(145deg,
+    #ffffff 0%,
+    rgba(211, 232, 224, 0.1) 50%,
     #ffffff 100%) !important;
+}
+
+.about-section__content {
+  background-color: rgba(255, 255, 255, 0.85);
+  padding: 2rem;
+  border-radius: 0.5rem;
 }
 
 /* Enhanced section title */
 h2.text-center {
- background: linear-gradient(135deg, 
+ background: linear-gradient(135deg,
     var(--bottle-green-primary) 50%,
     var(--bottle-green-medium) 80%,
     var(--bottle-green-primary) 80%) !important;

--- a/it/landingPage.html
+++ b/it/landingPage.html
@@ -116,10 +116,10 @@
     top: 0; left: 0; width: 100%; height: 100%;
     z-index: 1;
     background: url('../assets/img/ceiling-4f.png') center center / cover no-repeat;
-    opacity: 0.11;
+    opacity: 0.05;
     pointer-events: none;">
   </div>
-  <div class="container position-relative" style="z-index: 2;">
+  <div class="container position-relative about-section__content" style="z-index: 2;">
     <h2 class="mb-4 text-center" style="color: #222; font-weight: 700; font-size: 30px; padding-bottom: 30px;">
       Mostre delle Scuole di Montesca e Rovigliano <br> Bruxelles 1910 — Città di Castello 2024 <br>
     </h2>


### PR DESCRIPTION
## Summary
- Soften overlay behind "Mostre delle Scuole" section by reducing background image opacity.
- Add semi-opaque white background to section content for improved text readability.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b10e95afec8332b4cde13c8deec614