### PR TITLE
Improve landing page text styling

### DIFF
--- a/css/pages/landingPage.css
+++ b/css/pages/landingPage.css
@@ -248,15 +248,16 @@
   border-radius: 0.5rem;
 }
 
+.about-section__content p {
+  font-weight: 500;
+  color: #111;
+  line-height: 1.6;
+}
+
 /* Enhanced section title */
 h2.text-center {
- background: linear-gradient(135deg,
-    var(--bottle-green-primary) 50%,
-    var(--bottle-green-medium) 80%,
-    var(--bottle-green-primary) 80%) !important;
-  -webkit-background-clip: text !important;
-  -webkit-text-fill-color: transparent !important;
-  background-clip: text !important;
+  color: #000;
+  font-weight: 700;
 }
 
 /*───────────────────────────────────────────────────────────────────────────────

--- a/en/landingPage.html
+++ b/en/landingPage.html
@@ -120,7 +120,7 @@
     pointer-events: none;">
   </div>
   <div class="container position-relative" style="z-index: 2;">
-    <h2 class="mb-4 text-center" style="color: #222; font-weight: 700; font-size: 30px; padding-bottom: 30px;">Montesca & Rovigliano Schools Exhibitions <br> Brussels 1910 — Città di Castello 2024 <br> </h2>
+    <h2 class="mb-4 text-center" style="font-size: 30px; padding-bottom: 30px;">Montesca & Rovigliano Schools Exhibitions <br> Brussels 1910 — Città di Castello 2024 <br> </h2>
     
     <!-- First Section: Image Left, Text Right -->
     <div class="row justify-content-center align-items-stretch g-0 mt-5" style="padding-bottom: 40px;">

--- a/it/landingPage.html
+++ b/it/landingPage.html
@@ -120,7 +120,7 @@
     pointer-events: none;">
   </div>
   <div class="container position-relative about-section__content" style="z-index: 2;">
-    <h2 class="mb-4 text-center" style="color: #222; font-weight: 700; font-size: 30px; padding-bottom: 30px;">
+    <h2 class="mb-4 text-center" style="font-size: 30px; padding-bottom: 30px;">
       Mostre delle Scuole di Montesca e Rovigliano <br> Bruxelles 1910 — Città di Castello 2024 <br>
     </h2>
     


### PR DESCRIPTION
## Summary
- Switch landing page section header to solid color and bold weight for better contrast.
- Add paragraph styling within the about-section to improve readability.
- Remove inline color styles from landing page headers in English and Italian versions to rely on CSS.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b114af136083329e63aef7bb9abc78