### PR TITLE
Enable default English captions on YouTube embeds

### DIFF
--- a/en/by-components.html
+++ b/en/by-components.html
@@ -217,7 +217,7 @@
                 </div>
                 <iframe
                   id="baroness-iframe"
-                  src="https://www.youtube.com/embed/8Q7N5qP0Yc4?si=J1uHctloucfDXAEp"
+                  src="https://www.youtube.com/embed/8Q7N5qP0Yc4?si=J1uHctloucfDXAEp&cc_load_policy=1&cc_lang_pref=en"
                   title="YouTube video player"
                   frameborder="0"
                   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
@@ -275,7 +275,7 @@
                 </div>
                 <iframe
                   id="expo-iframe"
-                  src="https://www.youtube.com/embed/OnbyfdafI-k?si=iIsB9aQI8DR8CALN"
+                  src="https://www.youtube.com/embed/OnbyfdafI-k?si=iIsB9aQI8DR8CALN&cc_load_policy=1&cc_lang_pref=en"
                   title="YouTube video player"
                   frameborder="0"
                   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
@@ -816,7 +816,7 @@
                onclick="this.style.display='none'; document.getElementById('play-button').style.display='none'; document.getElementById('display-iframe').style.display='block';" />
           <iframe
                   id="display-iframe"
-                  src="https://www.youtube.com/embed/55w8NbbbDRY"
+                  src="https://www.youtube.com/embed/55w8NbbbDRY?cc_load_policy=1&cc_lang_pref=en"
                   title="The Display - Exhibition Video"
                   frameborder="0"
                   allowfullscreen


### PR DESCRIPTION
## Summary
- enable English captions by default on baroness, expo, and display YouTube iframes

## Testing
- `npm test` *(fails: Could not read package.json)*
- `apt-get update` *(fails: repository is not signed / 403)*
- `curl -s http://localhost:8000/en/by-components.html | rg 'cc_load_policy'`


------
https://chatgpt.com/codex/tasks/task_e_68b1297879a88332a3f4fe0564e9a584